### PR TITLE
Improve custom layouts

### DIFF
--- a/archetypes/projects.md
+++ b/archetypes/projects.md
@@ -1,0 +1,13 @@
+---
+title: "{{ replace .Name "-" " " | title }}"
+date: {{ .Date }}
+draft: true
+
+# Project metadata
+github: "https://github.com/user/repo"
+
+# Standard Hugo params
+summary: "A brief summary of the project for the list page."
+---
+
+This is the main description of your project. You can write about the project's goals, your contributions, and any interesting challenges you faced. You can use **Markdown** freely.

--- a/assets/css/extented/custom.css
+++ b/assets/css/extented/custom.css
@@ -2,29 +2,29 @@
 .paper-meta {
     background-color: var(--secondary);
     border-radius: var(--radius);
-    padding: 15px 20px;
+    padding: 1rem;
     margin-bottom: 20px;
-    font-size: 0.9em;
     border: 1px solid var(--border-color);
-  }
-  
-  .paper-meta-item {
-    margin-bottom: 8px;
-  }
-  
-  .paper-meta-item:last-child {
-    margin-bottom: 0;
-  }
-  
-  .paper-meta .meta-label {
-    font-weight: bold;
-    color: var(--primary-text-color);
-    margin-right: 8px;
-  }
-  
-  .paper-meta .meta-value {
-    color: var(--secondary-text-color);
-  }
+}
+
+.paper-meta-items {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+}
+
+.paper-meta-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.9em;
+}
+
+.paper-meta-item .icon {
+    width: 1.2rem;
+    height: 1.2rem;
+    stroke-width: 1.5;
+}
   
   /* For responsive YouTube embeds */
   .video-container {

--- a/assets/js/talkListMap.js
+++ b/assets/js/talkListMap.js
@@ -1,1 +1,29 @@
+document.addEventListener('DOMContentLoaded', function () {
+    var mapElement = document.getElementById('map-list');
+    var talkDataElement = document.getElementById('talk-data');
 
+    if (mapElement && talkDataElement) {
+        var locations = JSON.parse(talkDataElement.textContent.trim());
+
+        if (locations.length > 0) {
+            var map = L.map('map-list').setView([locations[0].lat, locations[0].lon], 4);
+
+            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                maxZoom: 18,
+                attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+            }).addTo(map);
+
+            var markers = [];
+            locations.forEach(function(loc) {
+                var marker = L.marker([loc.lat, loc.lon]).addTo(map);
+                marker.bindPopup(`<b><a href="${loc.url}">${loc.title}</a></b><br>${loc.event}`);
+                markers.push(marker);
+            });
+
+            var group = new L.featureGroup(markers);
+            map.fitBounds(group.getBounds().pad(0.5));
+        } else {
+            mapElement.style.display = 'none';
+        }
+    }
+});

--- a/layouts/papers/single.html
+++ b/layouts/papers/single.html
@@ -13,22 +13,9 @@
     {{- end }}
     {{- if not (.Param "hideMeta") }}
     <div class="post-meta">
-      {{- if .IsTranslated -}}
-      <ul class="i18n_list">
-        {{- i18n "translations" | default "Translations" }}: 
-        {{- range .Translations }}
-        <li>
-          <a href="{{ .Permalink }}">
-            {{- if (and .Language.LanguageName .Language.ContentDir) }}
-            {{- .Language.LanguageName | emojify -}}
-            {{- else }}
-            {{- .Lang | emojify -}}
-            {{- end -}}
-          </a>
-        </li>
-        {{- end }}
-      </ul>
-      {{- end }}
+        <span>{{ .Date.Format "January 2, 2006" }}</span>
+        <span class="dot-divider"></span>
+        <span>{{ .ReadingTime }} min read</span>
     </div>
     {{- end }}
   </header>
@@ -37,28 +24,28 @@
   <!-- START OF CUSTOM PAPER METADATA     -->
   <!-- ================================== -->
   <div class="paper-meta">
-    {{ with .Params.authors }}
-    <div class="paper-meta-item">
-      <span class="meta-label">Authors:</span>
-      <span class="meta-value">{{ delimit . ", " }}</span>
-    </div>
-    {{ end }}
+    <div class="paper-meta-items">
+      {{ with .Params.authors }}
+      <div class="paper-meta-item">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-users"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M9 7m-4 0a4 4 0 1 0 8 0a4 4 0 1 0 -8 0" /><path d="M3 21v-2a4 4 0 0 1 4 -4h4a4 4 0 0 1 4 4v2" /><path d="M16 3.13a4 4 0 0 1 0 7.75" /><path d="M21 21v-2a4 4 0 0 0 -3 -3.85" /></svg>
+        <span>{{ delimit . ", " }}</span>
+      </div>
+      {{ end }}
 
-    {{ with .Params.journal }}
-    <div class="paper-meta-item">
-      <span class="meta-label">Journal:</span>
-      <span class="meta-value"><em>{{ . }}</em></span>
-    </div>
-    {{ end }}
-    
-    {{ with .Params.doi }}
-    <div class="paper-meta-item">
-      <span class="meta-label">DOI:</span>
-      <span class="meta-value">
+      {{ with .Params.journal }}
+      <div class="paper-meta-item">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-book"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M3 19a9 9 0 0 1 9 0a9 9 0 0 1 9 0" /><path d="M3 6a9 9 0 0 1 9 0a9 9 0 0 1 9 0" /><path d="M3 6l0 13" /><path d="M12 6l0 13" /><path d="M21 6l0 13" /></svg>
+        <span><em>{{ . }}</em></span>
+      </div>
+      {{ end }}
+
+      {{ with .Params.doi }}
+      <div class="paper-meta-item">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-link"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M10 14a3.5 3.5 0 0 0 5 0l4 -4a3.5 3.5 0 0 0 -5 -5l-.5 .5" /><path d="M14 10a3.5 3.5 0 0 0 -5 0l-4 4a3.5 3.5 0 0 0 5 5l.5 -.5" /></svg>
         <a href="https://doi.org/{{ . }}" target="_blank" rel="noopener noreferrer">{{ . }}</a>
-      </span>
+      </div>
+      {{ end }}
     </div>
-    {{ end }}
   </div>
   <!-- ================================== -->
   <!-- END OF CUSTOM PAPER METADATA       -->

--- a/layouts/projects/list.html
+++ b/layouts/projects/list.html
@@ -1,0 +1,42 @@
+{{- define "main" }}
+
+<div class="page-header">
+    <h1>{{ .Title }}</h1>
+    {{- if .Description }}
+    <div class="page-description">{{ .Description }}</div>
+    {{- end }}
+</div>
+
+<div class="posts">
+  {{- range .Pages.GroupByDate "2006" }}
+  <div class="archive-year">
+    <h2 class="archive-year-header">
+      {{.Key}}
+    </h2>
+    {{- range .Pages }}
+    <article class="post-entry">
+      <header class="entry-header">
+        <h2>
+          {{ .Title }}
+          {{- if .Draft }}<div class="draft-tag">DRAFT</div>{{- end }}
+        </h2>
+      </header>
+      <div class="entry-content">
+        <p>{{ .Summary | plainify | safeHTML }}</p>
+      </div>
+      <footer class="entry-footer">
+        {{- with .Params.github -}}
+        <span class="entry-meta-event">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-brand-github"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M9 19c-4.3 1.4 -4.3 -2.5 -6 -3m12 5v-3.5c0 -1 .1 -1.4 -.5 -2c2.8 -.3 5.5 -1.4 5.5 -6a4.6 4.6 0 0 0 -1.3 -3.2a4.2 4.2 0 0 0 -.1 -3.2s-1.1 -.3 -3.5 1.3a12.3 12.3 0 0 0 -6.2 0c-2.4 -1.6 -3.5 -1.3 -3.5 -1.3a4.2 4.2 0 0 0 -.1 3.2a4.6 4.6 0 0 0 -1.3 3.2c0 4.6 2.7 5.7 5.5 6c-.6 .6 -.6 1.2 -.5 2v3.5" /></svg>
+            <a href="{{ . }}" target="_blank" rel="noopener noreferrer">{{ . }}</a>
+        </span>
+        {{- end -}}
+      </footer>
+      <a class="entry-link" aria-label="post link to {{ .Title | plainify }}" href="{{ .Permalink }}"></a>
+    </article>
+    {{- end }}
+  </div>
+  {{- end }}
+</div>
+
+{{- end }}{{/* end main */}}

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -1,0 +1,55 @@
+{{- define "main" }}
+
+<article class="post-single">
+  <header class="post-header">
+    <h1 class="post-title">
+      {{ .Title }}
+      {{- if .Draft }}<div class="draft-tag">DRAFT</div>{{- end }}
+    </h1>
+    {{- if .Description }}
+    <div class="post-description">
+      {{ .Description }}
+    </div>
+    {{- end }}
+    {{- if not (.Param "hideMeta") }}
+    <div class="post-meta">
+        <span>{{ .Date.Format "January 2, 2006" }}</span>
+        <span class="dot-divider"></span>
+        <span>{{ .ReadingTime }} min read</span>
+    </div>
+    {{- end }}
+  </header>
+
+  <!-- ================================== -->
+  <!-- START OF CUSTOM PROJECT METADATA   -->
+  <!-- ================================== -->
+  <div class="paper-meta">
+    <div class="paper-meta-items">
+      {{ with .Params.github }}
+      <div class="paper-meta-item">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-brand-github"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M9 19c-4.3 1.4 -4.3 -2.5 -6 -3m12 5v-3.5c0 -1 .1 -1.4 -.5 -2c2.8 -.3 5.5 -1.4 5.5 -6a4.6 4.6 0 0 0 -1.3 -3.2a4.2 4.2 0 0 0 -.1 -3.2s-1.1 -.3 -3.5 1.3a12.3 12.3 0 0 0 -6.2 0c-2.4 -1.6 -3.5 -1.3 -3.5 -1.3a4.2 4.2 0 0 0 -.1 3.2a4.6 4.6 0 0 0 -1.3 3.2c0 4.6 2.7 5.7 5.5 6c-.6 .6 -.6 1.2 -.5 2v3.5" /></svg>
+        <a href="{{ . }}" target="_blank" rel="noopener noreferrer">{{ . }}</a>
+      </div>
+      {{ end }}
+    </div>
+  </div>
+  <!-- ================================== -->
+  <!-- END OF CUSTOM PROJECT METADATA     -->
+  <!-- ================================== -->
+
+  <div class="post-content">
+    {{- .Content -}}
+  </div>
+
+  <footer class="post-footer">
+    {{- if .Params.tags }}
+    <ul class="post-tags">
+      {{- range .Params.tags }}
+      <li><a href="{{ "tags/" | absLangURL }}{{ . | urlize }}">{{ . }}</a></li>
+      {{- end }}
+    </ul>
+    {{- end }}
+  </footer>
+</article>
+
+{{- end }}{{/* end main */}}

--- a/layouts/talks/list.html
+++ b/layouts/talks/list.html
@@ -8,46 +8,19 @@
 </div>
 
 <div id="map-list" class="map-container"></div>
-<script>
-    {{- /* Fixes Hugo's parser */ -}}
-    // Define map locations from Hugo data
-    const locations = [
-        {{- range .Pages -}}
-            {{- $page := . -}}
-            {{- with .Params.location -}}
-                {{- if and .lat .lon }}
-                    {
-                        "lat": {{ .lat }},
-                        "lon": {{ .lon }},
-                        "title": "{{- $page.Title | safeJS -}}",
-                        "event": "{{- .name | safeJS -}}",
-                        "url": "{{- $page.Permalink | safeJS -}}"
-                    },
-                {{- end -}}
+<!-- Create a placeholder for the talk data -->
+<div id="talk-data" style="display: none;">
+    {{- $locations := slice -}}
+    {{- range .Pages -}}
+        {{- with .Params.location -}}
+            {{- if and .lat .lon -}}
+                {{- $locations = $locations | append (dict "lat" .lat "lon" .lon "title" $.Title "event" .name "url" $.Permalink) -}}
             {{- end -}}
         {{- end -}}
-    ];
-
-    if (locations.length > 0) {
-        // ... rest of the script is unchanged ...
-        var map = L.map('map-list').setView([locations[0].lat, locations[0].lon], 4);
-
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            maxZoom: 18,
-            attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-        }).addTo(map);
-
-        locations.forEach(function(loc) {
-            var marker = L.marker([loc.lat, loc.lon]).addTo(map);
-            marker.bindPopup(`<b><a href="${loc.url}">${loc.title}</a></b><br>${loc.event}`);
-        });
-        
-        var group = new L.featureGroup(locations.map(loc => L.marker([loc.lat, loc.lon])));
-        map.fitBounds(group.getBounds().pad(0.5));
-    } else {
-        document.getElementById('map-list').style.display = 'none';
-    }
-</script>
+    {{- end -}}
+    {{- $locations | jsonify -}}
+</div>
+<script src="{{ "/js/talkListMap.js" | relURL }}"></script>
 
 <div class="posts">
   {{- range .Pages.GroupByDate "2006" }}
@@ -78,6 +51,12 @@
              {{ . }}
           {{- end -}}
         </span>
+        {{- with .Params.location.name -}}
+        <span class="entry-meta-event">
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-map-pin"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M9 11a3 3 0 1 0 6 0a3 3 0 0 0 -6 0" /><path d="M17.657 16.657l-4.243 4.243a2 2 0 0 1 -2.827 0l-4.244 -4.243a8 8 0 1 1 11.314 0z" /></svg>
+           {{ . }}
+        </span>
+        {{- end -}}
       </footer>
       <a class="entry-link" aria-label="post link to {{ .Title | plainify }}" href="{{ .Permalink }}"></a>
     </article>

--- a/layouts/talks/single.html
+++ b/layouts/talks/single.html
@@ -13,23 +13,9 @@
     {{- end }}
     {{- if not (.Param "hideMeta") }}
     <div class="post-meta">
-      {{- partial "post_meta.html" . -}}
-      {{- if .IsTranslated -}}
-      <ul class="i18n_list">
-        {{- i18n "translations" | default "Translations" }}: 
-        {{- range .Translations }}
-        <li>
-          <a href="{{ .Permalink }}">
-            {{- if (and .Language.LanguageName .Language.ContentDir) }}
-            {{- .Language.LanguageName | emojify -}}
-            {{- else }}
-            {{- .Lang | emojify -}}
-            {{- end -}}
-          </a>
-        </li>
-        {{- end }}
-      </ul>
-      {{- end }}
+        <span>{{ .Date.Format "January 2, 2006" }}</span>
+        <span class="dot-divider"></span>
+        <span>{{ .ReadingTime }} min read</span>
     </div>
     {{- end }}
   </header>
@@ -38,43 +24,34 @@
   <!-- START OF CUSTOM TALK METADATA      -->
   <!-- ================================== -->
   <div class="paper-meta">
-    {{ with .Params.presentation }}
-    <div class="paper-meta-item">
-      <span class="meta-label">Presentation:</span>
-      <span class="meta-value">{{ . }}</span>
+    <div class="paper-meta-items">
+      {{ with .Params.type }}
+      <div class="paper-meta-item">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-presentation"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M3 4l18 0" /><path d="M4 4v10a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-10" /><path d="M12 16l0 4" /><path d="M9 20l6 0" /></svg>
+        <span>{{ . }}</span>
+      </div>
+      {{ end }}
+      {{ with .Params.event }}
+      <div class="paper-meta-item">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-building-community"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M8 9l5 5v7h-5v-4l-5 4v-7l5 -5" /><path d="M6 21v-7m-2 2l8 -8l-4 -4l-4 4l8 8" /><path d="M18 18h4v-4h-4v4z" /></svg>
+        <span>{{ . }}</span>
+      </div>
+      {{ end }}
+      {{ with .Params.location }}
+      <div class="paper-meta-item">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-map-pin"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M9 11a3 3 0 1 0 6 0a3 3 0 0 0 -6 0" /><path d="M17.657 16.657l-4.243 4.243a2 2 0 0 1 -2.827 0l-4.244 -4.243a8 8 0 1 1 11.314 0z" /></svg>
+        <span>{{ .name }}</span>
+      </div>
+      {{ end }}
     </div>
-    {{ end }}
-    {{ with .Params.event }}
-    <div class="paper-meta-item">
-      <span class="meta-label">Event:</span>
-      <span class="meta-value">{{ . }}</span>
-    </div>
-    {{ end }}
-    {{ with .Params.location }}
-    <div class="paper-meta-item">
-      <span class="meta-label">Location:</span>
-      <span class="meta-value">{{ .name }}</span>
-    </div>
-    {{ end }}
   </div>
   <!-- ================================== -->
   <!-- END OF CUSTOM TALK METADATA        -->
   <!-- ================================== -->
 
   {{- if and .Params.location .Params.location.lat .Params.location.lon }}
-  <div id="map" class="map-container" data-lat="{{ .Params.location.lat }}" data-lon="{{ .Params.location.lon }}" data-event="{{ .Params.event }}" data-location-name="{{ .Params.location.name }}"></div>
-  <script>
-      {{- /* Fixes Hugo's parser */ -}}
-      var map = L.map('map').setView([parseFloat(document.getElementById('map').dataset.lat), parseFloat(document.getElementById('map').dataset.lon)], 13);
-      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-          maxZoom: 19,
-          attribution: '© <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
-      }).addTo(map);
-      var marker = L.marker([parseFloat(document.getElementById('map').dataset.lat), parseFloat(document.getElementById('map').dataset.lon)]).addTo(map);
-      marker.bindPopup("<b>" + document.getElementById('map').dataset.event + "</b><br>" + document.getElementById('map').dataset.locationName).openPopup();
-  </script>
   <div id="map" class="map-container" data-lat="{{ .Params.location.lat }}" data-lon="{{ .Params.location.lon }}" data-event="{{ .Params.event | safeJS }}" data-location-name="{{ .Params.location.name | safeJS }}"></div>
-  <script src="{{ "/assets/js/talkMap.js" | absURL }}"></script>
+  <script src="{{ "/js/talkMap.js" | relURL }}"></script>
   {{- end }}
 
   {{- if .Params.youtube }}


### PR DESCRIPTION
This commit improves the custom layouts for papers, talks, and projects.

- Papers: Improved the metadata display to be more similar to the default, with icons for authors, journal, and DOI.
- Talks: Improved the metadata display and fixed the LeafletJS integration. The map is now displayed correctly on the list and single pages.
- Projects: Created a new layout for projects with a metadata section for the GitHub link.