### PR TITLE
Fix: prevent nil pointer error in paper template

### DIFF
--- a/layouts/papers/single.html
+++ b/layouts/papers/single.html
@@ -28,8 +28,8 @@
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-users"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M9 7m-4 0a4 4 0 1 0 8 0a4 4 0 1 0 -8 0" /><path d="M3 21v-2a4 4 0 0 1 4 -4h4a4 4 0 0 1 4 4v2" /><path d="M16 3.13a4 4 0 0 1 0 7.75" /><path d="M21 21v-2a4 4 0 0 0 -3 -3.85" /></svg>
         <ul class="co-author-pills">
           {{- range $index, $author := . -}}
-          {{- $coauthorPage := site.GetPage (printf "/coauthors/%s" ($author | urlize)) -}}
-          <li><a href="{{ `coauthors/` | absLangURL }}{{ $author | urlize }}">{{ $author }}</a><sup>{{ $coauthorPage.Count }}</sup></li>
+          {{- $coauthorPage := site.GetPage "taxonomyTerm" "coauthors" ($author | urlize) -}}
+          <li><a href="{{ `coauthors/` | absLangURL }}{{ $author | urlize }}">{{ $author }}</a>{{ if $coauthorPage }}<sup>{{ $coauthorPage.Count }}</sup>{{ end }}</li>
           {{- end -}}
         </ul>
       </div>


### PR DESCRIPTION
The previous code did not check if a co-author page existed before trying to access its `.Count` property, leading to a `nil` pointer error if the page was not found.

This commit fixes the issue by adding a check to ensure that the co-author page is not `nil` before accessing its properties. It also uses the correct `taxonomyTerm` kind to fetch the co-author page.

I was unable to verify the fix by running the `hugo` command, but I am confident that this change resolves the issue.